### PR TITLE
reading, photos: use YAML for index, instead of markdown tables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,23 @@
+# ABOUTME: Makefile for building and installing kizai static site generator
+# ABOUTME: Provides minimal targets for build, install, clean, and help operations
+
+BINARY_NAME=kizai
+
+.PHONY: help build install clean
+
+help:
+	@echo "Available targets:"
+	@echo "  build   - Build the binary"
+	@echo "  install - Install the binary"
+	@echo "  clean   - Remove build artifacts"
+	@echo "  help    - Show this help message"
+
+build:
+	go build -o $(BINARY_NAME) .
+
+install:
+	go install .
+
+clean:
+	go clean
+	rm -f $(BINARY_NAME)

--- a/markdown/markdown.go
+++ b/markdown/markdown.go
@@ -29,6 +29,7 @@ type Page struct {
 	Body     string
 	Post     *Post
 	Posts    []*Post
+	Yaml     map[string]interface{}
 }
 
 type Post struct {
@@ -54,6 +55,33 @@ func (p *Page) ParseMarkdown(file string) error {
 	}
 
 	p.Markdown = string(md)
+	return nil
+}
+
+// ParseYAML parse a YAML file into frontmatter and YAML data
+func (p *Page) ParseYAML(file string) error {
+	fl, err := os.Open(file)
+	if err != nil {
+		return err
+	}
+	defer fl.Close()
+
+	var yamlData map[string]interface{}
+	md, err := frontmatter.Parse(fl, &yamlData)
+	if err != nil {
+		return err
+	}
+
+	p.Frontmatter = yamlData
+	p.Yaml = yamlData
+
+	// If there's an intro field, use it as markdown
+	if intro, ok := yamlData["intro"].(string); ok {
+		p.Markdown = intro
+	} else {
+		p.Markdown = string(md)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Markdown tables are hard to manage and scale horribly. Instead use YAML to define the index for photos and reading, for now. It simply reads YAML and then forwards that to Go templating. The templates in danishpraka.sh/ then render the different YAML fields for an item (book or photos).

Also adds a markdown file.